### PR TITLE
feat: Improve mobile responsiveness of Sudoku game

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
             transition: background-color 0.2s ease-in-out, transform 0.1s ease, color 0.2s ease-in-out;
             display: inline-flex; align-items: center; justify-content: center;
             height: 2.25rem; 
-            padding-left: 0.75rem; 
-            padding-right: 0.75rem; 
+            padding-left: 0.5rem; 
+            padding-right: 0.5rem; 
             border-radius: 0.375rem; 
             font-weight: 500; 
         }
@@ -138,7 +138,7 @@
         <div class="flex-grow m-1 sm:m-2 flex flex-col items-center justify-center p-1 sm:p-2 rounded-lg custom-scrollbar"
              :style="{ backgroundColor: boardBgColor }">
             
-            <div id="sudoku-grid" class="grid grid-cols-9 gap-px bg-slate-600 border border-slate-600 sm:border-2 sm:border-slate-500 rounded shadow-md sm:rounded-md sm:shadow-lg select-none w-full max-w-[calc(100vmin-80px)] sm:max-w-xs md:max-w-sm lg:max-w-md xl:max-w-lg">
+            <div id="sudoku-grid" class="grid grid-cols-9 gap-px bg-slate-600 border border-slate-600 sm:border-2 sm:border-slate-500 rounded shadow-md sm:rounded-md sm:shadow-lg select-none w-full max-w-[calc(100vw-40px)] sm:max-w-xs md:max-w-sm lg:max-w-md xl:max-w-lg">
                 <template v-for="(row, r_idx) in sudokuGrid" :key="r_idx">
                     <div v-for="(cell, c_idx) in row" :key="`${r_idx}-${c_idx}`"
                          class="sudoku-cell aspect-square flex items-center justify-center text-lg sm:text-xl md:text-2xl lg:text-3xl font-medium cursor-pointer border border-slate-500 sm:border-slate-600"
@@ -161,12 +161,12 @@
             <div id="number-pad" class="mt-3 sm:mt-4 grid grid-cols-5 gap-1 sm:gap-1.5 md:gap-2">
                 <button v-for="num in [1,2,3,4,5,6,7,8,9]" :key="num"
                         @click="inputNumber(num)"
-                        class="tool-button w-8 h-8 text-base sm:w-10 sm:h-10 sm:text-lg md:w-12 md:h-12 md:text-xl lg:w-14 lg:h-14 lg:text-2xl bg-sky-600 hover:bg-sky-500 text-white rounded-md">
+                        class="tool-button w-7 h-7 text-sm sm:w-9 sm:h-9 sm:text-base md:w-10 md:h-10 md:text-lg lg:w-12 lg:h-12 lg:text-xl bg-sky-600 hover:bg-sky-500 text-white rounded-md">
                     {{num}}
                 </button>
                 <button @click="inputNumber(0)" title="Clear cell (Backspace/Delete)"
-                        class="tool-button w-8 h-8 sm:w-10 sm:h-10 md:w-12 md:h-12 lg:w-14 lg:h-14 bg-slate-600 hover:bg-slate-500 text-white rounded-md">
-                    <i class="fas fa-backspace text-sm sm:text-base md:text-lg"></i>
+                        class="tool-button w-7 h-7 sm:w-9 sm:h-9 md:w-10 md:h-10 lg:w-12 lg:h-12 bg-slate-600 hover:bg-slate-500 text-white rounded-md">
+                    <i class="fas fa-backspace text-xs sm:text-sm md:text-base"></i>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
This commit introduces several changes to enhance the mobile-friendliness of the Sudoku game page:

1.  **Sudoku Grid:** Adjusted the maximum width of the Sudoku grid on small screens to use `calc(100vw-40px)`. This allows the grid to better utilize available horizontal space on mobile devices while preventing overflow. Larger screen sizes retain their previous max-width settings.

2.  **Number Pad:** Reduced the base size and text size of the number pad buttons. Responsive breakpoints for these buttons have also been adjusted to smaller sizes, ensuring the number pad remains compact and usable on smaller viewports.

3.  **Toolbar:** Decreased the default horizontal padding for toolbar buttons (e.g., "New", "Check", "Solve"). This provides more horizontal space on small screens, improving the layout and reducing potential button crowding.

These changes collectively improve your experience on mobile devices by making the game interface more adaptable to various screen sizes.