### PR TITLE
refactor: Enlarge number pad buttons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,12 +161,12 @@
             <div id="number-pad" class="mt-3 sm:mt-4 grid grid-cols-5 gap-1 sm:gap-1.5 md:gap-2">
                 <button v-for="num in [1,2,3,4,5,6,7,8,9]" :key="num"
                         @click="inputNumber(num)"
-                        class="tool-button w-7 h-7 text-sm sm:w-9 sm:h-9 sm:text-base md:w-10 md:h-10 md:text-lg lg:w-12 lg:h-12 lg:text-xl bg-sky-600 hover:bg-sky-500 text-white rounded-md">
+                        class="tool-button w-9 h-9 text-base sm:w-10 sm:h-10 sm:text-lg md:w-12 md:h-12 md:text-xl lg:w-14 lg:h-14 lg:text-2xl bg-sky-600 hover:bg-sky-500 text-white rounded-md">
                     {{num}}
                 </button>
                 <button @click="inputNumber(0)" title="Clear cell (Backspace/Delete)"
-                        class="tool-button w-7 h-7 sm:w-9 sm:h-9 md:w-10 md:h-10 lg:w-12 lg:h-12 bg-slate-600 hover:bg-slate-500 text-white rounded-md">
-                    <i class="fas fa-backspace text-xs sm:text-sm md:text-base"></i>
+                        class="tool-button w-9 h-9 sm:w-10 sm:h-10 md:w-12 md:h-12 lg:w-14 lg:h-14 bg-slate-600 hover:bg-slate-500 text-white rounded-md">
+                    <i class="fas fa-backspace text-base sm:text-lg md:text-xl"></i>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
Based on your feedback, this commit increases the size of the number pad buttons specifically for mobile/small screen sizes.

The base size for these buttons is now w-9 h-9 with text-base. The sizes for sm, md, and lg breakpoints have been restored to their original, larger dimensions (sm:w-10, md:w-12, lg:w-14).

This change aims to improve usability and visibility of the number pad on smaller devices.