### PR TITLE
refactor: Further enlarge number pad buttons for mobile usability

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,12 +161,12 @@
             <div id="number-pad" class="mt-3 sm:mt-4 grid grid-cols-5 gap-1 sm:gap-1.5 md:gap-2">
                 <button v-for="num in [1,2,3,4,5,6,7,8,9]" :key="num"
                         @click="inputNumber(num)"
-                        class="tool-button w-9 h-9 text-base sm:w-10 sm:h-10 sm:text-lg md:w-12 md:h-12 md:text-xl lg:w-14 lg:h-14 lg:text-2xl bg-sky-600 hover:bg-sky-500 text-white rounded-md">
+                        class="tool-button w-10 h-10 text-lg sm:w-12 sm:h-12 sm:text-xl md:w-14 md:h-14 md:text-2xl lg:w-16 lg:h-16 lg:text-3xl bg-sky-600 hover:bg-sky-500 text-white rounded-md">
                     {{num}}
                 </button>
                 <button @click="inputNumber(0)" title="Clear cell (Backspace/Delete)"
-                        class="tool-button w-9 h-9 sm:w-10 sm:h-10 md:w-12 md:h-12 lg:w-14 lg:h-14 bg-slate-600 hover:bg-slate-500 text-white rounded-md">
-                    <i class="fas fa-backspace text-base sm:text-lg md:text-xl"></i>
+                        class="tool-button w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 lg:w-16 lg:h-16 bg-slate-600 hover:bg-slate-500 text-white rounded-md">
+                    <i class="fas fa-backspace text-lg sm:text-xl md:text-2xl lg:text-3xl"></i>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
Based on continued user feedback, this commit further increases the size of the number pad buttons for an improved experience on mobile/small screen sizes.

The base size for these buttons is now w-10 h-10 with text-lg. Responsive sizes have been scaled up accordingly:
- sm: w-12 h-12 text-xl
- md: w-14 h-14 text-2xl
- lg: w-16 h-16 text-3xl

This change aims to ensure the number pad buttons are comfortably large and easy to interact with on all devices, especially phones.