### PR TITLE
style: Apply distinct default colors to mode button icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,17 +200,17 @@
                 <button @click="currentInputMode = 'normal'"
                         aria-label="Normal input mode"
                         :class="['tool-button p-2 sm:p-2.5 text-sm sm:text-base rounded-md', currentInputMode === 'normal' ? 'bg-blue-600 text-white ring-2 ring-blue-400' : 'bg-slate-600 hover:bg-slate-500 text-gray-200']">
-                    <i class="fas fa-pencil-alt"></i>
+                    <i class="fas fa-pencil-alt" :class="currentInputMode === 'normal' ? 'text-white' : 'text-sky-400'"></i>
                 </button>
                 <button @click="currentInputMode = 'red'"
                         aria-label="Red candidate input mode"
                         :class="['tool-button p-2 sm:p-2.5 text-sm sm:text-base rounded-md', currentInputMode === 'red' ? 'bg-red-600 text-white ring-2 ring-red-400' : 'bg-slate-600 hover:bg-slate-500 text-gray-200']">
-                    <i class="fas fa-pencil-alt"></i>
+                    <i class="fas fa-pencil-alt" :class="currentInputMode === 'red' ? 'text-white' : 'text-red-400'"></i>
                 </button>
                 <button @click="currentInputMode = 'green'"
                         aria-label="Green candidate input mode"
                         :class="['tool-button p-2 sm:p-2.5 text-sm sm:text-base rounded-md', currentInputMode === 'green' ? 'bg-green-600 text-white ring-2 ring-green-400' : 'bg-slate-600 hover:bg-slate-500 text-gray-200']">
-                    <i class="fas fa-pencil-alt"></i>
+                    <i class="fas fa-pencil-alt" :class="currentInputMode === 'green' ? 'text-white' : 'text-green-400'"></i>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
Refines the styling of the mode selection button icons to ensure they are visually distinguishable even when their respective buttons are not active.

- Icons for Normal, Red Candidate, and Green Candidate modes now have distinct default colors (`text-sky-400`, `text-red-400`, `text-green-400` respectively) applied via dynamic `:class` binding on the `<i>` tag.
- When a mode button becomes active, its icon color now changes to `text-white` (also via the dynamic `:class` binding), ensuring good contrast against the button's active background color.

This addresses feedback that the previous icon-only buttons were not clear enough as the icons themselves were not persistently colored.