### PR TITLE
fix: Correct Sudoku validation logic for duplicates

### DIFF
--- a/index.html
+++ b/index.html
@@ -600,6 +600,9 @@
                         this.showMessage("Game Over", "You've already solved this puzzle!", "info");
                         return;
                     }
+                    const numericGrid = this.sudokuGrid.map(row => 
+                        row.map(cell => cell.currentValue)
+                    );
                     this.clearAllErrors(); 
                     let hasErrors = false;
                     let isFull = true;
@@ -611,7 +614,7 @@
                             if (cell.currentValue === 0) {
                                 isFull = false;
                             } else { 
-                                if (!this.sudokuGenerator._isValidPlacement(this.sudokuGrid, r_idx, c_idx, cell.currentValue)) {
+                                if (!this.sudokuGenerator._isValidPlacement(numericGrid, r_idx, c_idx, cell.currentValue)) {
                                     cell.isError = true; 
                                     hasErrors = true;
                                 }


### PR DESCRIPTION
Resolves a bug where the Sudoku validation (`checkPuzzle` method) failed to detect duplicate numbers within the same row, column, or 3x3 box.

The `_isValidPlacement` method in `SudokuGenerator` expects a 2D grid of numbers for its checks. However, `checkPuzzle` was previously passing `this.sudokuGrid` directly, which is a 2D grid of cell objects (e.g., `{ currentValue: 5, ... }`). This caused comparisons like `grid[r][i] === val` to always be false, as an object was being compared to a number.

The fix involves:
- Modifying `checkPuzzle()` to first create a `numericGrid` by mapping `this.sudokuGrid` to a 2D array of `cell.currentValue`.
- Passing this `numericGrid` to `_isValidPlacement` instead of `this.sudokuGrid`.

The `_isValidPlacement` method itself was reviewed and its logic is sound for a numeric grid. With the correct data type now being passed, the validation for duplicates in rows, columns, and boxes functions as intended.