### PR TITLE
feat: Improve highlight visibility of related cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
                             'bg-sky-700 ring-1 sm:ring-2 ring-sky-500 sm:ring-sky-400 z-10': isSelected(r_idx, c_idx),
                             'bg-red-800/30 hover:bg-red-700/50': !isSelected(r_idx, c_idx) && cell.isError,
                             'bg-sky-600/40': !isSelected(r_idx, c_idx) && !cell.isError && isSameNumber(r_idx, c_idx),
-                            'bg-slate-700/50': !isSelected(r_idx, c_idx) && !cell.isError && !isSameNumber(r_idx, c_idx) && isRelated(r_idx, c_idx),
+                            'bg-slate-600': !isSelected(r_idx, c_idx) && !cell.isError && !isSameNumber(r_idx, c_idx) && isRelated(r_idx, c_idx),
                             'bg-slate-800 hover:bg-slate-700/70': !isSelected(r_idx, c_idx) && !cell.isError && !isSameNumber(r_idx, c_idx) && !isRelated(r_idx, c_idx) && !cell.fixed,
                             'bg-slate-800/60': !isSelected(r_idx, c_idx) && !cell.isError && !isSameNumber(r_idx, c_idx) && !isRelated(r_idx, c_idx) && cell.fixed,
                              'border-r-slate-400 dark:border-r-slate-300': (c_idx + 1) % 3 === 0 && c_idx !== 8,


### PR DESCRIPTION
I replaced the `bg-slate-700/50` class with `bg-slate-600` for the related cells' background highlight. This provides a more distinct and visible highlight for the row, column, and 3x3 box of the selected cell.